### PR TITLE
rack's dependency choice by ruby version

### DIFF
--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',     '~> 3.4.0'
   spec.add_development_dependency 'simplecov', '~> 0.11.2'
 
-  spec.add_runtime_dependency 'rack', '>= 1.6.0'
+  # without it bundler trying to get last rack version, but it needs ruby >= '2.2.2'
+  spec.add_runtime_dependency 'rack', RUBY_VERSION <= '2.2.2' ? '~> 1.6' : '>= 1.6.0'
   spec.add_runtime_dependency 'jwt',  '~> 1.5.2'
 end


### PR DESCRIPTION
Travis-CI deployment was with error because gem was badly managed dependency of rack. For rack newer then 1.6.5 minimum required ruby version is 2.2.2, so i fixed that.
As you can see, build successfully deployed and passed for my repository.
https://travis-ci.org/xfynx/rack-jwt/builds/199188429

Same is actual for local usage with older ruby versions.
So you can agree this commit, freeze rack version to 1.6.5 at max (bad idea) or disable ruby versions older then 2.2.2.