### PR TITLE
Support exclude paths with Regexp

### DIFF
--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -124,9 +124,9 @@ describe Rack::JWT::Auth do
         end
       end
 
-      describe 'when Array contains non-String elements' do
+      describe 'when Array contains non-String and non-Regexp elements' do
         it 'raises an exception' do
-          args = { secret: secret, exclude: ['/foo', nil, '/bar'] }
+          args = { secret: secret, exclude: ['/foo', nil, '/bar', /\/foo/] }
           expect { Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
         end
       end


### PR DESCRIPTION
Thank you so much for this gem. This saved me considerable amount of time and effort. I'm using this and I don't want to exclude some sub paths with certain uri params for e.g.
```
/api/v1/user # should be excluded
```
```
/api/v1/user/<user_id>/something # should not be excluded
```

This feature allows to use String as well as Regex in exclude, so that we can do
```
exclude: [/api\/v1\/user.+/]
```