### PR TITLE
add logging; allow both strings and regex excludes v2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rspec/core/rake_task'
 
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new do |t|
-    t.verbose = true
+  t.verbose = true
 end
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,55 +1,9 @@
-require 'pry'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-VERSION = Bundler::GemHelper.instance.gemspec.version.to_s
-TAG = "v#{VERSION}"
-NAME = Bundler::GemHelper.instance.gemspec.name
-PUSH_URL = "https://#{ENV['GEMFURY_SECRET']}@push.fury.io/waybetter/"
-PKG_FN = "pkg/#{NAME}-#{VERSION}.gem"
-
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new do |t|
-  t.verbose = true
-end
-
-#desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
-#           "To prevent publishing in Rubygems use `gem_push=no rake release`"
-#                              "release:guard_clean",
-#                              "release:source_control_push",
-#                              "release:gemfury_push"] do
-#end
-Rake::Task["release"].clear # dangerous, slip
-desc "(Default rake release disabled, see wb_release)"
-task :release do
-  puts "Did you mean 'wb-release'? Please see rake -T."
-end
-
-task "check_gemfury_repo_access" do
-  unless ENV['GEMFURY_SECRET']
-    warn "It doesn't look like you have GEMFURY_SECRET set. Cannot continue."
-    exit(1)
-  end
-end
-
-desc "Create tag #{TAG}, push --tags, send pkg/#{NAME}-#{VERSION} to gemfury.\nYou must set GEMFURY_SECRET=<our private repo>"
-task "wb_release" => ["check_gemfury_repo_access",
-                      "build",
-                      "release:guard_clean",
-                      "release:source_control_push"] do
-  if File.exist?(fn = File.expand_path(PKG_FN, '.'))
-    cmd = "curl -F package=@#{PKG_FN} #{PUSH_URL}"
-    puts cmd
-    `#{cmd}`
-    if $?.exitstatus.eql?(0)
-      puts "\n\n#{fn} now up on gemfury."
-    else
-      warn "\n\nUpload of #{fn} FAILED"
-    end
-  else
-    warn "Didn't find #{fn}, cannot push it"
-    exit(1)
-  end
+    t.verbose = true
 end
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -4,14 +4,16 @@ require 'rspec/core/rake_task'
 
 require_relative 'lib/rack/jwt/version.rb'
 
+VERSION = Rack::JWT::VERSION
+TAG = "v#{VERSION}"
+NAME = Bundler::GemHelper.instance.gemspec.name
+PUSH_URL = "https://#{ENV['GEM_SECRET']}@push.fury.io/waybetter/"
+PKG_FN = "pkg/#{NAME}-#{VERSION}.gem"
 
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new do |t|
   t.verbose = true
 end
-
-version=Rack::JWT::VERSION
-tag="v#{version}"
 
 #desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
 #           "To prevent publishing in Rubygems use `gem_push=no rake release`"
@@ -20,17 +22,36 @@ tag="v#{version}"
 #                              "release:gemfury_push"] do
 #end
 Rake::Task["release"].clear # dangerous, slip
-desc "[Default rake release disabled, see wb_release]"
+desc "(Default rake release disabled, see wb_release)"
 task :release do
   puts "Did you mean 'wb-release'? Please see rake -T."
 end
 
-desc "Create tag #{tag}, push --tags, send pkg/rack-jwt-#{version} to gemfury"
-task "wb_release" => ["build",
+task "check_gemfury_repo_access" do
+  unless ENV['GEM_SECRET']
+    warn "It doesn't look like you have WB_GEM_SOURCE set. Cannot continue."
+    exit(1)
+  end
+end
+
+desc "Create tag #{TAG}, push --tags, send pkg/#{NAME}-#{VERSION} to gemfury.\nYou must set WB_GEM_SOURCE=<our private repo>"
+task "wb_release" => ["check_gemfury_repo_access",
+                      "build",
                       "release:guard_clean",
                       "release:source_control_push"] do
-  require 'pry'; binding.pry
-  1
+  if File.exist?(fn = File.expand_path(PKG_FN, '.'))
+    cmd = "curl -F package=@#{PKG_FN} #{PUSH_URL}"
+    puts cmd
+    `#{cmd}`
+    if $?.exitstatus.eql?(0)
+      puts "\n\n#{fn} now up on gemfury."
+    else
+      warn "\n\nUpload of #{fn} FAILED"
+    end
+  else
+    warn "Didn't find #{fn}, cannot push it"
+    exit(1)
+  end
 end
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,10 @@ require 'pry'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-require_relative 'lib/rack/jwt/version.rb'
-
-VERSION = Rack::JWT::VERSION
+VERSION = Bundler::GemHelper.instance.gemspec.version.to_s
 TAG = "v#{VERSION}"
 NAME = Bundler::GemHelper.instance.gemspec.name
-PUSH_URL = "https://#{ENV['WB_GEM_SECRET']}@push.fury.io/waybetter/"
+PUSH_URL = "https://#{ENV['GEMFURY_SECRET']}@push.fury.io/waybetter/"
 PKG_FN = "pkg/#{NAME}-#{VERSION}.gem"
 
 desc 'Run RSpec'
@@ -15,25 +13,30 @@ RSpec::Core::RakeTask.new do |t|
   t.verbose = true
 end
 
-Rake::Task["release"].clear
+#desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
+#           "To prevent publishing in Rubygems use `gem_push=no rake release`"
+#                              "release:guard_clean",
+#                              "release:source_control_push",
+#                              "release:gemfury_push"] do
+#end
+Rake::Task["release"].clear # dangerous, slip
 desc "(Default rake release disabled, see wb_release)"
 task :release do
   puts "Did you mean 'wb-release'? Please see rake -T."
 end
 
 task "check_gemfury_repo_access" do
-  unless ENV['WB_GEM_SECRET']
-    warn "It doesn't look like you have WB_GEM_SECRET set. Cannot continue."
+  unless ENV['GEMFURY_SECRET']
+    warn "It doesn't look like you have GEMFURY_SECRET set. Cannot continue."
     exit(1)
   end
 end
 
-desc "Create tag #{TAG}, push --tags, send pkg/#{NAME}-#{VERSION} to gemfury.\nYou must set WB_GEM_SOURCE=<our private repo>"
+desc "Create tag #{TAG}, push --tags, send pkg/#{NAME}-#{VERSION} to gemfury.\nYou must set GEMFURY_SECRET=<our private repo>"
 task "wb_release" => ["check_gemfury_repo_access",
                       "build",
                       "release:guard_clean",
                       "release:source_control_push"] do
-
   if File.exist?(fn = File.expand_path(PKG_FN, '.'))
     cmd = "curl -F package=@#{PKG_FN} #{PUSH_URL}"
     puts cmd
@@ -44,10 +47,9 @@ task "wb_release" => ["check_gemfury_repo_access",
       warn "\n\nUpload of #{fn} FAILED"
     end
   else
-    warn "Didn't find #{fn}, cannot push package"
+    warn "Didn't find #{fn}, cannot push it"
     exit(1)
   end
-
 end
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require_relative 'lib/rack/jwt/version.rb'
 VERSION = Rack::JWT::VERSION
 TAG = "v#{VERSION}"
 NAME = Bundler::GemHelper.instance.gemspec.name
-PUSH_URL = "https://#{ENV['GEM_SECRET']}@push.fury.io/waybetter/"
+PUSH_URL = "https://#{ENV['WB_GEM_SECRET']}@push.fury.io/waybetter/"
 PKG_FN = "pkg/#{NAME}-#{VERSION}.gem"
 
 desc 'Run RSpec'
@@ -22,8 +22,8 @@ task :release do
 end
 
 task "check_gemfury_repo_access" do
-  unless ENV['GEM_SECRET']
-    warn "It doesn't look like you have WB_GEM_SOURCE set. Cannot continue."
+  unless ENV['WB_GEM_SECRET']
+    warn "It doesn't look like you have WB_GEM_SECRET set. Cannot continue."
     exit(1)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,36 @@
+require 'pry'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+
+require_relative 'lib/rack/jwt/version.rb'
+
 
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new do |t|
   t.verbose = true
+end
+
+version=Rack::JWT::VERSION
+tag="v#{version}"
+
+#desc "Create tag #{version_tag} and build and push #{name}-#{version}.gem to Rubygems\n" \
+#           "To prevent publishing in Rubygems use `gem_push=no rake release`"
+#                              "release:guard_clean",
+#                              "release:source_control_push",
+#                              "release:gemfury_push"] do
+#end
+Rake::Task["release"].clear # dangerous, slip
+desc "[Default rake release disabled, see wb_release]"
+task :release do
+  puts "Did you mean 'wb-release'? Please see rake -T."
+end
+
+desc "Create tag #{tag}, push --tags, send pkg/rack-jwt-#{version} to gemfury"
+task "wb_release" => ["build",
+                      "release:guard_clean",
+                      "release:source_control_push"] do
+  require 'pry'; binding.pry
+  1
 end
 
 task default: :spec

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.3.3'.freeze
+    VERSION = '0.3.4'.freeze
   end
 end

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.3.1'.freeze
+    VERSION = '0.3.2'.freeze
   end
 end

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -124,9 +124,9 @@ describe Rack::JWT::Auth do
         end
       end
 
-      describe 'when Array contains non-String elements' do
+      describe 'when Array contains non-String and non-regex elements' do
         it 'raises an exception' do
-          args = { secret: secret, exclude: ['/foo', nil, '/bar'] }
+          args = { secret: secret, exclude: [1234, nil, '/bar'] }
           expect { Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
         end
       end


### PR DESCRIPTION
[ note: originally we sent this as PR #4, but allowed some cruft to get into the branch of that PR. This is a resend from an isolated branch with just the changes intended for the PR]

We're using this gem for JWT auth, but wanted 401s to show up in our app logs, and also a little more flexibility in excludes (in a backwards-compatible way).  

This PR adds the ability to pass a logger in, and also to use regex patterns for excludes.

- If an exclude is a string, path rules for string are as they used to be (must
  start with '/', and excludes paths that start_with? the string pattern.  

- If an exclude is a regex, path is excluded if it matches the regex

Here is an example rails config:
```ruby

    config.jwt = {
      secret:  ENV.fetch('MY_JWT_SECRET', 'test-secret'),
      algorithm: 'HS256'
    }

    config.middleware.use Rack::JWT::Auth, {
      secret: config.jwt[:secret],
      logger: config.logger,
      options: {
        algorithm: config.jwt[:algorithm]
      },
      exclude: [
        /.*noauth$/,
        '/exclude-me'
      ],
    }
```
