### PR TITLE
Update ruby-jwt gem to ~> 2.0

### DIFF
--- a/lib/rack/jwt/token.rb
+++ b/lib/rack/jwt/token.rb
@@ -5,6 +5,7 @@ module Rack
       # abc123.abc123.abc123    (w/ signature)
       # abc123.abc123.          ('none')
       TOKEN_REGEX = /\A([a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]*)\z/
+      DEFAULT_HEADERS = {typ: 'JWT'}
 
       def self.encode(payload, secret, alg = 'HS256')
         raise 'Invalid payload. Must be a Hash.' unless payload.is_a?(Hash)
@@ -14,9 +15,9 @@ module Rack
         # if using an unsigned token ('none' alg) you *must* set the `secret`
         # to `nil` in which case any user provided `secret` will be ignored.
         if alg == 'none'
-          ::JWT.encode(payload, nil, alg)
+          ::JWT.encode(payload, nil, alg, DEFAULT_HEADERS)
         else
-          ::JWT.encode(payload, secret, alg)
+          ::JWT.encode(payload, secret, alg, DEFAULT_HEADERS)
         end
       end
 

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end

--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   # without it bundler trying to get last rack version, but it needs ruby >= '2.2.2'
   spec.add_runtime_dependency 'rack', RUBY_VERSION <= '2.2.2' ? '~> 1.6' : '>= 1.6.0'
-  spec.add_runtime_dependency 'jwt',  '~> 1.5.2'
+  spec.add_runtime_dependency 'jwt',  '~> 2.0'
 end


### PR DESCRIPTION
Update `ruby-jwt` gem to the 2.x series.

Test failures revealed that the `ruby-jwt` gem no longer sets the `typ` header by default, so we now set `DEFAULT_HEADERS` ourself when encoding new JWTs for backwards compatability.