### PR TITLE
Add ED25519 to the SUPPORTED_ALGORITHMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - sudo apt-get install -y libsodium18
 language: ruby
 rvm:
   - 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 before_install:
   - sudo apt-get install -y libsodium18
+dist: xenial
 language: ruby
 rvm:
   - 2.3.8

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ gem install rack-jwt
 
 * `verify` : optional : Boolean : Determines whether JWT will verify tokens keys for mismatch key types when decoded. Default is `true`. Set to `false` if you are using the `'none'` algorithm.
 
-* `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims and algorithms. See [the ruby-jwt docs](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names) for much more info on the available options and how they work. These options are passed through without change to the underlying `ruby-jwt` gem. By default only expiration (exp) and Not Before (nbf) claims are verified. Pass in an algorithm choice like `{ algorithm: 'HS256' }`.
+* `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims and algorithms. See the ruby-jwt docs for [more information of the algorithms and their requirements](https://github.com/jwt/ruby-jwt#algorithms-and-usage) as well as [more information on the supported claims](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names). These options are passed through without change to the underlying `ruby-jwt` gem. By default only expiration (exp) and Not Before (nbf) claims are verified. Pass in an algorithm choice like `{ algorithm: 'HS256' }`.
 
 * `exclude` : optional : Array : An Array of path strings representing paths that should not be checked for the presence of a valid JWT token. Excludes sub-paths as of specified paths as well (e.g. `%w(/docs)` excludes `/docs/some/thing.html` also). Each path should start with a `/`. If a path matches the current request path this entire middleware is skipped and no authentication or verification of tokens takes place.
 
@@ -81,10 +81,14 @@ the [ruby-jwt gem repo](https://github.com/jwt/ruby-jwt/blob/master/README.md)
 The `algorithm` is an optional String and can be one of the following (default HMAC 'HS256'):
 
 ```ruby
-%w(none HS256 HS384 HS512 RS256 RS384 RS512 ES256 ES384 ES512)
+%w(none HS256 HS384 HS512 RS256 RS384 RS512 ED25519 ES256 ES384 ES512)
 
 HS256 is the default
 ```
+
+Note that `ED25519` support depends on the `rbnacl` which is _not_ already included by the
+`rack-jwt` gem. If you wish to use the `ED25519` algorith, you must also manually require
+`rbnacl` gem in addition to `rack-jwt`.
 
 Here is a sample payload with illustrative data. You don't have to use all,
 or even most, of these.

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -9,7 +9,20 @@ module Rack
       attr_reader :options
       attr_reader :exclude
 
-      SUPPORTED_ALGORITHMS = %w(none HS256 HS384 HS512 RS256 RS384 RS512 ES256 ES384 ES512).freeze
+      SUPPORTED_ALGORITHMS = [
+        'none',
+        'HS256',
+        'HS384',
+        'HS512',
+        'RS256',
+        'RS384',
+        'RS512',
+        'ES256',
+        'ES384',
+        'ES512',
+        ('ED25519' if defined?(RbNaCl)),
+      ].compact.freeze
+
       DEFAULT_ALGORITHM = 'HS256'.freeze
 
       # The last segment gets dropped for 'none' algorithm since there is no
@@ -94,10 +107,7 @@ module Rack
       end
 
       def check_secret_type!
-        unless @secret.nil? ||
-               @secret.is_a?(String) ||
-               @secret.is_a?(OpenSSL::PKey::RSA) ||
-               @secret.is_a?(OpenSSL::PKey::EC)
+        unless Token.secret_of_valid_type?(@secret)
           raise ArgumentError, 'secret argument must be a valid type'
         end
       end

--- a/lib/rack/jwt/token.rb
+++ b/lib/rack/jwt/token.rb
@@ -38,6 +38,15 @@ module Rack
         end
       end
 
+      def self.secret_of_valid_type?(secret)
+        secret.nil? ||
+          secret.is_a?(String) ||
+          secret.is_a?(OpenSSL::PKey::RSA) ||
+          secret.is_a?(OpenSSL::PKey::EC)  ||
+          (defined?(RbNaCl) && secret.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)) ||
+          (defined?(RbNaCl) && secret.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey))
+      end
+
       # Private Utility Class Methods
       # See : https://gist.github.com/Integralist/bb8760d11a03c88da151
 
@@ -55,14 +64,6 @@ module Rack
         verify.nil? || verify.is_a?(FalseClass) || verify.is_a?(TrueClass)
       end
       private_class_method :verify_of_valid_type?
-
-      def self.secret_of_valid_type?(secret)
-        secret.nil? ||
-          secret.is_a?(String) ||
-          secret.is_a?(OpenSSL::PKey::RSA) ||
-          secret.is_a?(OpenSSL::PKey::EC)
-      end
-      private_class_method :secret_of_valid_type?
     end
   end
 end

--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '>= 1.0.0'
   spec.add_development_dependency 'rspec',     '>= 3.8.0'
   spec.add_development_dependency 'simplecov', '>= 0.16.0'
+  spec.add_development_dependency 'rbnacl',    '>= 6.0.1'
 
   spec.add_runtime_dependency 'rack'
   spec.add_runtime_dependency 'jwt',  '~> 2.1.0'


### PR DESCRIPTION
Since using this algorithm requires `rbnacl` as a dependency, it is only enabled when `RbNaCl` is defined. This retains backwards compatibility, i.e. prevents existing users from having to install a new dependency when upgrading `rack-jwt`.

See https://github.com/jwt/ruby-jwt#algorithms-and-usage.