### PR TITLE
Remove setting of Content-Length by default

### DIFF
--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -184,7 +184,7 @@ module Rack
 
       def return_error(message)
         body    = { error: message }.to_json
-        headers = { 'Content-Type' => 'application/json', 'Content-Length' => body.bytesize.to_s }
+        headers = { 'Content-Type' => 'application/json' }
 
         [401, headers, [body]]
       end


### PR DESCRIPTION
This is to allow users to use Rack::ContentLength if they wish to set Content-Length by default.

#### context

Since Rails 5.0, it is noted that Rack::ContentLength is no longer part of the Rack spec. 
> see https://github.com/rails/rails/commit/56903585a099ab67a7acfaaef0a02db8fe80c450

As such, i think we do not need to set the Content-Length by default too.

In any case, users can simply make use of the Rack::Content-Length to set that if needed (regardless of Rails 5.0 or older)