### PR TITLE
Relax JWT pin to allow minor upgrades

### DIFF
--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rbnacl',    '>= 6.0.1'
 
   spec.add_runtime_dependency 'rack'
-  spec.add_runtime_dependency 'jwt',  '~> 2.1.0'
+  spec.add_runtime_dependency 'jwt',  '~> 2.1'
 end


### PR DESCRIPTION
This PR relaxes the version pin on the jwt gem.  This allows upgrades of any 2.x.x jwt gem release after 2.1.0.  Current jwt gem version is 2.2.1.

Resolves #18 