### PR TITLE
Set minimum Ruby version to 2.4.0 (JWKS code uses methods not available in 2.3)

### DIFF
--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
   spec.platform      = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.3.8'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_development_dependency 'bundler',   '>= 1.16.2'
   spec.add_development_dependency 'rake',      '>= 12.0.0'


### PR DESCRIPTION
The new JWKS functionality uses the method OpenSSL::PKey::RSA#set_key which is only available (according to stdlib documentation) from Ruby 2.4.0 onwards. This bumps the minimum Ruby version to be compatible.

The alternative would be to find a way of constructing the RSA key from numerical components using methods available back then, but I can't see an obvious alternative other than encoding and loading from a string (seems like a bad approach).