### PR TITLE
Exclude auth for root path only

### DIFF
--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -167,7 +167,10 @@ module Rack
       end
 
       def path_matches_excluded_path?(env)
-        @exclude.any? { |ex| env['PATH_INFO'].start_with?(ex) }
+        @exclude.any? { |ex|
+          path = env['PATH_INFO']
+          ex == '/' ? path == ex : path.start_with?(ex)
+        }
       end
 
       def valid_auth_header?(env)

--- a/spec/exclusion_spec.rb
+++ b/spec/exclusion_spec.rb
@@ -49,6 +49,18 @@ describe Rack::JWT::Auth do
       end
     end
 
+    describe 'passes through when root is excluded' do
+      let(:app) { Rack::JWT::Auth.new(inner_app, secret: secret, exclude: ['/']) }
+
+      it 'returns a 200' do
+        get('/')
+        expect(last_response.status).to eq 200
+
+        get('/somewhere')
+        expect(last_response.status).to eq 401
+      end
+    end
+
     describe 'fails when no matching path and no token' do
       let(:app) { Rack::JWT::Auth.new(inner_app, secret: secret, exclude: %w(/docs /books /static)) }
 


### PR DESCRIPTION
Hey @eparreno 👋 

Merging this PR will allow a dev to exclude the root path (`'/'`) without excluding all paths starting with a `/` from the JWT token auth check. 
This comes handy when we want to have a pretty landing/docs page mounted on `/` and an JWT auth API that serves from other paths, i.e. `/users`.
