### PR TITLE
Add JWK support,

### DIFF
--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -114,7 +114,7 @@ module Rack
 
       def check_secret!
         if @secret.nil? || (@secret.is_a?(String) && @secret.empty?)
-          unless @options[:algorithm] == 'none'
+          if @options[:algorithm] != 'none' && @options[:jwks].nil?
             raise ArgumentError, 'secret argument can only be nil/empty for the "none" algorithm'
           end
         end

--- a/lib/rack/jwt/token.rb
+++ b/lib/rack/jwt/token.rb
@@ -7,17 +7,19 @@ module Rack
       TOKEN_REGEX = /\A([a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]*)\z/
       DEFAULT_HEADERS = {typ: 'JWT'}
 
-      def self.encode(payload, secret, alg = 'HS256')
+      def self.encode(payload, secret, alg = 'HS256', headers = {})
         raise 'Invalid payload. Must be a Hash.' unless payload.is_a?(Hash)
         raise 'Invalid secret type.'             unless secret_of_valid_type?(secret)
         raise 'Unsupported algorithm'            unless algorithm_supported?(alg)
 
+        headers = DEFAULT_HEADERS.merge(headers)
+
         # if using an unsigned token ('none' alg) you *must* set the `secret`
         # to `nil` in which case any user provided `secret` will be ignored.
         if alg == 'none'
-          ::JWT.encode(payload, nil, alg, DEFAULT_HEADERS)
+          ::JWT.encode(payload, nil, alg, headers)
         else
-          ::JWT.encode(payload, secret, alg, DEFAULT_HEADERS)
+          ::JWT.encode(payload, secret, alg, headers)
         end
       end
 

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module JWT
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -93,6 +93,17 @@ describe Rack::JWT::Auth do
         end
       end
 
+      describe 'when algorithm is given and secret is nil and verify not false and jwks given' do
+        let(:app) { Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'none' }) }
+
+        it 'succeeds' do
+          jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+          header 'Authorization', "Bearer #{issuer.encode(payload, jwk.keypair, 'RS512', {kid: jwk.kid})}"
+          get('/')
+          expect(last_response.status).to eq 200
+        end
+      end
+
       describe 'when algorithm "none" and secret not nil but verify is false' do
         it 'raises an exception' do
           args = { secret: secret, verify: false, options: { algorithm: 'none' } }

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -142,6 +142,23 @@ describe Rack::JWT::Auth do
       end
     end
 
+    describe 'with valid JWKS request' do
+      let(:rsa_private) { OpenSSL::PKey::RSA.generate(2048) }
+      let(:rsa_public)  { rsa_private.public_key }
+      let(:jwk) { JWT::JWK.new(rsa_private) }
+      let(:app) { Rack::JWT::Auth.new(inner_app, secret: nil, verify: verify, options: { algorithm: 'RS512', jwks: { keys: [jwk.export] }}) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, rsa_private, 'RS512', kid: jwk.kid)}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"RS512", "kid" => jwk.kid})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
     describe 'with valid EC ES256 key token' do
       ecdsa = OpenSSL::PKey::EC.new('prime256v1')
       ecdsa.generate_key


### PR DESCRIPTION
https://github.com/jwt/ruby-jwt/#json-web-key-jwk

Add JWT Key Set support to the middleware,
Allow custom headers on `Token` encode